### PR TITLE
feat: add docker/compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:lts
+
+WORKDIR /app/
+
+COPY . .
+RUN npm install -g pnpm
+RUN pnpm install
+COPY config/adminList.sample.yml config/adminList.yml
+COPY config/config.sample.yml config/config.yml
+COPY config/announcement.sample.md config/announcement.md
+RUN sed -i "s/host: 127.0.0.1/host: gh-db/g" config/config.yml
+RUN sed -i "s#path.join(__dirname, '../config/#path.join(__dirname, '../../config/#g" src/install/install.js
+
+EXPOSE 3000
+
+CMD [ "node", "app.js" ]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,30 @@
 - [可选] 进入 `adminList.yml` 以添加更多管理员
 - 启动 `pnpm start`
 
+## 部署(Docker compose)
+
+> 请确保您已经安装了 Docker 和 Docker Compose，视情况而定是否使用sudo提升权限
+
+- 克隆本仓库 `git clone https://github.com/GHAuth-Team/ghauth.git`
+- 进入仓库目录`cd ghauth`
+- 编译Docker镜像并自动运行`docker compose up -d`，如果遇到镜像编译网络问题参见下方的说明
+- 运行辅助配置助手`docker exec -it gh-app pnpm helper`，您可以与下方范例填写值不同，但需要同时修改docker-compose.yml中的容器名称
+  - MongoDB 主机: `gh-db`
+  - Redis 主机: `gh-redis`
+- 销毁镜像重载配置`docker compose down && docker compose up -d`
+
+> 如果遇到这样的问题，禁用buildkit
+>
+> - `export DOCKER_BUILDKIT=0 && export COMPOSE_DOCKER_CLI_BUILD=0`
+
+```shell
+ => ERROR [internal] load metadata for docker.io/library/node:lts          0.3s
+------
+ > [internal] load metadata for docker.io/library/node:lts:
+------
+failed to solve: rpc error: code = Unknown desc = failed to solve with frontend dockerfile.v0: failed to create LLB definition: unexpected status code [manifests lts]: 403 Forbidden
+```
+
 ## 部署(手动配置)
 
 - 克隆本仓库 `git clone https://github.com/GHAuth-Team/ghauth.git`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '3.9'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: gh-app
+    ports:
+      - '80:3000'
+    volumes:
+      - 'gh-config:/app/config'
+      - 'gh-skin:/app/skin'
+    networks:
+      - default
+      - ghdb-net
+    depends_on:
+      - db
+      - redis
+    restart: always
+
+  db:
+    image: 'mongo:latest'
+    container_name: 'gh-db'
+    volumes:
+      - 'gh-db:/data/db'
+    networks:
+      - ghdb-net
+    restart: always
+
+  redis:
+    image: 'redis:latest'
+    container_name: 'gh-redis'
+    volumes:
+      - 'gh-redis:/data'
+    networks:
+      - ghdb-net
+    restart: always
+
+volumes:
+  gh-config:
+  gh-skin:
+  gh-db:
+  gh-redis:
+
+networks:
+  app-net:
+  ghdb-net:


### PR DESCRIPTION
# 添加docker部署方式

## 包含内容

- docker-compose部署
- docker部署
- readme更新

## 存在的潜在问题

- 在config.yml中，mongodb的host配置十分难以定位，因此为了可以正常运行，Dockerfile中粗暴地将所有的`host: 127.0.0.1`替换，可能会存在潜在问题
  - 可能的解决方式：config.yml中，mongodb配置节下的`host: 127.0.0.1`替换为`host: 127.0.0.1 #mongo host`或者其他存在唯一行的特征的内容方便Dockerfile中使用sed替换，redis配置节同理。
- 在`src/install/install.js`中，有些地方使用例如`fs.existsSync('./install.lock')`的方式定位文件，有的地方使用`path.join(__dirname, '../config/config.yml')`的方式定位文件。后一种定位文件的方式存在`__dirname`路径是`src/install`的问题，例如config.yml会定位到`src/config/config.yml`，实际上这个路径并不存在。暂时没有好的办法，先在Dockerfile中粗暴地将它替换掉了。